### PR TITLE
Suggestion of a better cipher suite

### DIFF
--- a/config/template.conf
+++ b/config/template.conf
@@ -26,7 +26,7 @@ server {
     ssl_session_cache shared:SSL:50m;
     ssl_prefer_server_ciphers on;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!3DES:+HIGH:+MEDIUM;
+    ssl_ciphers EECDH+AES:+AES128:+AES256:+SHA;
     add_header Strict-Transport-Security "max-age=31536000;";
     
     # Uncomment the following directive after DH generation

--- a/config/yunohost_admin.conf
+++ b/config/yunohost_admin.conf
@@ -17,7 +17,7 @@ server {
     ssl_session_cache shared:SSL:50m;
     ssl_prefer_server_ciphers on;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!3DES:+HIGH:+MEDIUM;
+    ssl_ciphers EECDH+AES:+AES128:+AES256:+SHA;
     add_header Strict-Transport-Security "max-age=31536000;";
     
     location / {


### PR DESCRIPTION
With new RFC 7465, the cipher suite must be updated to new security standards.
I suggest you to use this cipher suite, it's simple and efficient.

Only outdated browsers are discarded with this setting (Android 2.3.7 and older, IE6 and 8 on XP, Java 6u45 and older,OpenSSL 0.9.8y and older)